### PR TITLE
Extract requester class to allow custom retry logic

### DIFF
--- a/digitalocean/Account.py
+++ b/digitalocean/Account.py
@@ -15,11 +15,11 @@ class Account(BaseAPI):
         super(Account, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token):
+    def get_object(cls, requester):
         """
             Class method that will return an Account object.
         """
-        acct = cls(token=api_token)
+        acct = cls(requester=requester)
         acct.load()
         return acct
 

--- a/digitalocean/Action.py
+++ b/digitalocean/Action.py
@@ -21,11 +21,11 @@ class Action(BaseAPI):
         super(Action, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, action_id):
+    def get_object(cls, requester, action_id):
         """
             Class method that will return a Action object by ID.
         """
-        action = cls(token=api_token, id=action_id)
+        action = cls(requester=requester, id=action_id)
         action.load_directly()
         return action
 

--- a/digitalocean/Balance.py
+++ b/digitalocean/Balance.py
@@ -12,11 +12,11 @@ class Balance(BaseAPI):
         super(Balance, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token):
+    def get_object(cls, requester):
         """
             Class method that will return an Balance object.
         """
-        acct = cls(token=api_token)
+        acct = cls(requester=requester)
         acct.load()
         return acct
 

--- a/digitalocean/Certificate.py
+++ b/digitalocean/Certificate.py
@@ -58,11 +58,11 @@ class Certificate(BaseAPI):
         super(Certificate, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, cert_id):
+    def get_object(cls, requester, cert_id):
         """
             Class method that will return a Certificate object by its ID.
         """
-        certificate = cls(token=api_token, id=cert_id)
+        certificate = cls(requester=requester, id=cert_id)
         certificate.load()
         return certificate
 

--- a/digitalocean/Domain.py
+++ b/digitalocean/Domain.py
@@ -13,11 +13,11 @@ class Domain(BaseAPI):
         super(Domain, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, domain_name):
+    def get_object(cls, requester, domain_name):
         """
             Class method that will return a Domain object by ID.
         """
-        domain = cls(token=api_token, name=domain_name)
+        domain = cls(requester=requester, name=domain_name)
         domain.load()
         return domain
 

--- a/digitalocean/Firewall.py
+++ b/digitalocean/Firewall.py
@@ -145,11 +145,11 @@ class Firewall(BaseAPI):
         super(Firewall, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, firewall_id):
+    def get_object(cls, requester, firewall_id):
         """
             Class method that will return a Firewall object by ID.
         """
-        firewall = cls(token=api_token, id=firewall_id)
+        firewall = cls(requester=requester, id=firewall_id)
         firewall.load()
         return firewall
 

--- a/digitalocean/FloatingIP.py
+++ b/digitalocean/FloatingIP.py
@@ -11,7 +11,7 @@ class FloatingIP(BaseAPI):
         super(FloatingIP, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, ip):
+    def get_object(cls, requester, ip):
         """
             Class method that will return a FloatingIP object by its IP.
 
@@ -19,7 +19,7 @@ class FloatingIP(BaseAPI):
                 api_token: str - token
                 ip: str - floating ip address
         """
-        floating_ip = cls(token=api_token, ip=ip)
+        floating_ip = cls(requester=requester, ip=ip)
         floating_ip.load()
         return floating_ip
 

--- a/digitalocean/Image.py
+++ b/digitalocean/Image.py
@@ -61,7 +61,7 @@ class Image(BaseAPI):
         super(Image, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, image_id_or_slug):
+    def get_object(cls, requester, image_id_or_slug):
         """
             Class method that will return an Image object by ID or slug.
 
@@ -70,10 +70,10 @@ class Image(BaseAPI):
             string, it will considered as slug.
         """
         if cls._is_string(image_id_or_slug):
-            image = cls(token=api_token, slug=image_id_or_slug)
+            image = cls(requester=requester, slug=image_id_or_slug)
             image.load(use_slug=True)
         else:
-            image = cls(token=api_token, id=image_id_or_slug)
+            image = cls(requester=requester, id=image_id_or_slug)
             image.load()
         return image
 

--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -163,7 +163,7 @@ class LoadBalancer(BaseAPI):
         super(LoadBalancer, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, id):
+    def get_object(cls, requester, id):
         """
         Class method that will return a LoadBalancer object by its ID.
 
@@ -171,7 +171,7 @@ class LoadBalancer(BaseAPI):
             api_token (str): DigitalOcean API token
             id (str): Load Balancer ID
         """
-        load_balancer = cls(token=api_token, id=id)
+        load_balancer = cls(requester=requester, id=id)
         load_balancer.load()
         return load_balancer
 

--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -33,13 +33,13 @@ class Manager(BaseAPI):
         """
             Returns an Account object.
         """
-        return Account.get_object(api_token=self.tokens)
+        return Account.get_object(requester=self._requester)
 
     def get_balance(self):
         """
             Returns a Balance object.
         """
-        return Balance.get_object(api_token=self.token)
+        return Balance.get_object(requester=self._requester)
 
     def get_all_regions(self):
         """
@@ -48,8 +48,7 @@ class Manager(BaseAPI):
         data = self.get_data("regions/")
         regions = list()
         for jsoned in data['regions']:
-            region = Region(**jsoned)
-            region.token = self.tokens
+            region = Region(**jsoned, requester=self._requester)
             regions.append(region)
         return regions
 
@@ -67,8 +66,7 @@ class Manager(BaseAPI):
 
         droplets = list()
         for jsoned in data['droplets']:
-            droplet = Droplet(**jsoned)
-            droplet.token = self.tokens
+            droplet = Droplet(**jsoned, requester=self._requester)
 
             for net in droplet.networks['v4']:
                 if net['type'] == 'private':
@@ -99,7 +97,7 @@ class Manager(BaseAPI):
         """
             Return a Droplet by its ID.
         """
-        return Droplet.get_object(api_token=self.tokens, droplet_id=droplet_id)
+        return Droplet.get_object(requester=self._requester, droplet_id=droplet_id)
 
     def get_all_sizes(self):
         """
@@ -108,8 +106,7 @@ class Manager(BaseAPI):
         data = self.get_data("sizes/")
         sizes = list()
         for jsoned in data['sizes']:
-            size = Size(**jsoned)
-            size.token = self.tokens
+            size = Size(**jsoned, requester=self._requester)
             sizes.append(size)
         return sizes
 
@@ -125,8 +122,7 @@ class Manager(BaseAPI):
         data = self.get_data("images/", params=params)
         images = list()
         for jsoned in data['images']:
-            image = Image(**jsoned)
-            image.token = self.tokens
+            image = Image(**jsoned, requester=self._requester)
             images.append(image)
         return images
 
@@ -143,7 +139,7 @@ class Manager(BaseAPI):
             Return a Image by its ID/Slug.
         """
         return Image.get_object(
-            api_token=self.tokens,
+            requester=self._requester,
             image_id_or_slug=image_id_or_slug,
         )
 
@@ -165,7 +161,6 @@ class Manager(BaseAPI):
         images = list()
         for i in data:
             if i.public:
-                i.token = self.tokens
                 images.append(i)
         return images
 
@@ -192,8 +187,7 @@ class Manager(BaseAPI):
         data = self.get_data("domains/")
         domains = list()
         for jsoned in data['domains']:
-            domain = Domain(**jsoned)
-            domain.token = self.tokens
+            domain = Domain(**jsoned, requester=self._requester)
             domains.append(domain)
         return domains
 
@@ -201,7 +195,7 @@ class Manager(BaseAPI):
         """
             Return a Domain by its domain_name
         """
-        return Domain.get_object(api_token=self.tokens, domain_name=domain_name)
+        return Domain.get_object(requester=self._requester, domain_name=domain_name)
 
     def get_all_sshkeys(self):
         """
@@ -210,8 +204,7 @@ class Manager(BaseAPI):
         data = self.get_data("account/keys/")
         ssh_keys = list()
         for jsoned in data['ssh_keys']:
-            ssh_key = SSHKey(**jsoned)
-            ssh_key.token = self.tokens
+            ssh_key = SSHKey(**jsoned, requester=self._requester)
             ssh_keys.append(ssh_key)
         return ssh_keys
 
@@ -219,7 +212,7 @@ class Manager(BaseAPI):
         """
             Return a SSHKey object by its ID.
         """
-        return SSHKey.get_object(api_token=self.tokens, ssh_key_id=ssh_key_id)
+        return SSHKey.get_object(requester=self._requester, ssh_key_id=ssh_key_id)
 
     def get_all_tags(self):
         """
@@ -227,14 +220,14 @@ class Manager(BaseAPI):
         """
         data = self.get_data("tags")
         return [
-            Tag(token=self.token, **tag) for tag in data['tags']
+            Tag(requester=self._requester, **tag) for tag in data['tags']
         ]
 
     def get_action(self, action_id):
         """
             Return an Action object by a specific ID.
         """
-        return Action.get_object(api_token=self.tokens, action_id=action_id)
+        return Action.get_object(requester=self._requester, action_id=action_id)
 
     def get_all_floating_ips(self):
         """
@@ -243,8 +236,7 @@ class Manager(BaseAPI):
         data = self.get_data("floating_ips")
         floating_ips = list()
         for jsoned in data['floating_ips']:
-            floating_ip = FloatingIP(**jsoned)
-            floating_ip.token = self.tokens
+            floating_ip = FloatingIP(**jsoned, requester=self._requester)
             floating_ips.append(floating_ip)
         return floating_ips
 
@@ -252,7 +244,7 @@ class Manager(BaseAPI):
         """
             Returns a of FloatingIP object by its IP address.
         """
-        return FloatingIP.get_object(api_token=self.tokens, ip=ip)
+        return FloatingIP.get_object(requester=self._requester, ip=ip)
 
     def get_all_load_balancers(self):
         """
@@ -262,8 +254,7 @@ class Manager(BaseAPI):
 
         load_balancers = list()
         for jsoned in data['load_balancers']:
-            load_balancer = LoadBalancer(**jsoned)
-            load_balancer.token = self.tokens
+            load_balancer = LoadBalancer(**jsoned, requester=self._requester)
             load_balancer.health_check = HealthCheck(**jsoned['health_check'])
             load_balancer.sticky_sessions = StickySessions(**jsoned['sticky_sessions'])
             forwarding_rules = list()
@@ -280,7 +271,7 @@ class Manager(BaseAPI):
             Args:
                 id (str): Load Balancer ID
         """
-        return LoadBalancer.get_object(api_token=self.tokens, id=id)
+        return LoadBalancer.get_object(requester=self._requester, id=id)
 
     def get_certificate(self, id):
         """
@@ -289,7 +280,7 @@ class Manager(BaseAPI):
             Args:
                 id (str): Certificate ID
         """
-        return Certificate.get_object(api_token=self.tokens, cert_id=id)
+        return Certificate.get_object(requester=self._requester, cert_id=id)
 
     def get_all_certificates(self):
         """
@@ -298,8 +289,7 @@ class Manager(BaseAPI):
         data = self.get_data("certificates")
         certificates = list()
         for jsoned in data['certificates']:
-            cert = Certificate(**jsoned)
-            cert.token = self.tokens
+            cert = Certificate(**jsoned, requester=self._requester)
             certificates.append(cert)
 
         return certificates
@@ -309,7 +299,7 @@ class Manager(BaseAPI):
             Return a Snapshot by its ID.
         """
         return Snapshot.get_object(
-            api_token=self.tokens, snapshot_id=snapshot_id
+            requester=self._requester, snapshot_id=snapshot_id
         )
 
     def get_all_snapshots(self):
@@ -318,7 +308,7 @@ class Manager(BaseAPI):
         """
         data = self.get_data("snapshots/")
         return [
-            Snapshot(token=self.tokens, **snapshot)
+            Snapshot(requester=self._requester, **snapshot)
             for snapshot in data['snapshots']
         ]
 
@@ -328,7 +318,7 @@ class Manager(BaseAPI):
         """
         data = self.get_data("snapshots?resource_type=droplet")
         return [
-            Snapshot(token=self.tokens, **snapshot)
+            Snapshot(reuester=self._requester, **snapshot)
             for snapshot in data['snapshots']
         ]
 
@@ -338,7 +328,7 @@ class Manager(BaseAPI):
         """
         data = self.get_data("snapshots?resource_type=volume")
         return [
-            Snapshot(token=self.tokens, **snapshot)
+            Snapshot(requester=self._requester, **snapshot)
             for snapshot in data['snapshots']
         ]
 
@@ -353,8 +343,7 @@ class Manager(BaseAPI):
         data = self.get_data(url)
         volumes = list()
         for jsoned in data['volumes']:
-            volume = Volume(**jsoned)
-            volume.token = self.tokens
+            volume = Volume(**jsoned, requester=self._requester)
             volumes.append(volume)
         return volumes
 
@@ -362,7 +351,7 @@ class Manager(BaseAPI):
         """
             Returns a Volume object by its ID.
         """
-        return Volume.get_object(api_token=self.tokens, volume_id=volume_id)
+        return Volume.get_object(requester=self._requester, volume_id=volume_id)
 
     def get_all_projects(self):
         """
@@ -371,8 +360,7 @@ class Manager(BaseAPI):
         data = self.get_data("projects")
         projects = list()
         for jsoned in data['projects']:
-            project = Project(**jsoned)
-            project.token = self.token
+            project = Project(**jsoned, requester=self._requester)
             projects.append(project)
         return projects
 
@@ -381,7 +369,7 @@ class Manager(BaseAPI):
             Return a Project by its ID.
         """
         return Project.get_object(
-            api_token=self.token,
+            requester=self._requester,
             project_id=project_id,
         )
 
@@ -390,7 +378,7 @@ class Manager(BaseAPI):
             Return default project of the account
         """
         return Project.get_object(
-            api_token=self.token,
+            requester=self._requester,
             project_id="default",
         )
 
@@ -401,8 +389,7 @@ class Manager(BaseAPI):
         data = self.get_data("firewalls")
         firewalls = list()
         for jsoned in data['firewalls']:
-            firewall = Firewall(**jsoned)
-            firewall.token = self.tokens
+            firewall = Firewall(**jsoned, requester=self._requester)
             in_rules = list()
             for rule in jsoned['inbound_rules']:
                 in_rules.append(InboundRule(**rule))
@@ -419,7 +406,7 @@ class Manager(BaseAPI):
             Return a Firewall by its ID.
         """
         return Firewall.get_object(
-            api_token=self.tokens,
+            requester=self._requester,
             firewall_id=firewall_id,
         )
 
@@ -429,7 +416,7 @@ class Manager(BaseAPI):
              Args:
                 id (str): The VPC's ID
         """
-        return VPC.get_object(api_token=self.token, vpc_id=id)
+        return VPC.get_object(requester=self._requester, vpc_id=id)
 
     def get_all_vpcs(self):
         """
@@ -438,8 +425,7 @@ class Manager(BaseAPI):
         data = self.get_data("vpcs")
         vpcs = list()
         for jsoned in data['vpcs']:
-            vpc = VPC(**jsoned)
-            vpc.token = self.token
+            vpc = VPC(**jsoned, requester=self._requester)
             vpcs.append(vpc)
 
         return vpcs
@@ -451,8 +437,7 @@ class Manager(BaseAPI):
         data = self.get_data("projects")
         projects = list()
         for jsoned in data['projects']:
-            project = Project(**jsoned)
-            project.token = self.token
+            project = Project(**jsoned, requester=self._requester)
             projects.append(project)
         return projects
 
@@ -461,7 +446,7 @@ class Manager(BaseAPI):
             Return a Project by its ID.
         """
         return Project.get_object(
-            api_token=self.token,
+            requester=self._requester,
             project_id=project_id,
         )
 
@@ -470,7 +455,7 @@ class Manager(BaseAPI):
             Return default project of the account
         """
         return Project.get_object(
-            api_token=self.token,
+            requester=self._requester,
             project_id="default",
         )
 

--- a/digitalocean/Project.py
+++ b/digitalocean/Project.py
@@ -17,14 +17,14 @@ class Project(BaseAPI):
         super(Project,self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, project_id):
+    def get_object(cls, requester, project_id):
         """Class method that will return a Project object by ID.
         Args:
             api_token (str): token
             kwargs (str): project id or project name
         """
 
-        project = cls(token=api_token, id=project_id)
+        project = cls(requester=requester, id=project_id)
         project.load()
         return project
 

--- a/digitalocean/Record.py
+++ b/digitalocean/Record.py
@@ -36,11 +36,11 @@ class Record(BaseAPI):
         super(Record, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, domain, record_id):
+    def get_object(cls, requester, domain, record_id):
         """
             Class method that will return a Record object by ID and the domain.
         """
-        record = cls(token=api_token, domain=domain, id=record_id)
+        record = cls(requester=requester, domain=domain, id=record_id)
         record.load()
         return record
 

--- a/digitalocean/SSHKey.py
+++ b/digitalocean/SSHKey.py
@@ -12,11 +12,11 @@ class SSHKey(BaseAPI):
         super(SSHKey, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, ssh_key_id):
+    def get_object(cls, requester, ssh_key_id):
         """
             Class method that will return a SSHKey object by ID.
         """
-        ssh_key = cls(token=api_token, id=ssh_key_id)
+        ssh_key = cls(requester=requester, id=ssh_key_id)
         ssh_key.load()
         return ssh_key
 

--- a/digitalocean/Snapshot.py
+++ b/digitalocean/Snapshot.py
@@ -16,11 +16,11 @@ class Snapshot(BaseAPI):
         super(Snapshot, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, snapshot_id):
+    def get_object(cls, requester, snapshot_id):
         """
             Class method that will return a Snapshot object by ID.
         """
-        snapshot = cls(token=api_token, id=snapshot_id)
+        snapshot = cls(requester=requester, id=snapshot_id)
         snapshot.load()
         return snapshot
 

--- a/digitalocean/Tag.py
+++ b/digitalocean/Tag.py
@@ -10,8 +10,8 @@ class Tag(BaseAPI):
 
 
     @classmethod
-    def get_object(cls, api_token, tag_name):
-        tag = cls(token=api_token, name=tag_name)
+    def get_object(cls, requester, tag_name):
+        tag = cls(requester=requester, name=tag_name)
         tag.load()
         return tag
 

--- a/digitalocean/VPC.py
+++ b/digitalocean/VPC.py
@@ -41,11 +41,11 @@ class VPC(BaseAPI):
         super(VPC, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, vpc_id):
+    def get_object(cls, requester, vpc_id):
         """
             Class method that will return a VPC object by its ID.
         """
-        vpc = cls(token=api_token, id=vpc_id)
+        vpc = cls(requester=requester, id=vpc_id)
         vpc.load()
         return vpc
 

--- a/digitalocean/Volume.py
+++ b/digitalocean/Volume.py
@@ -19,11 +19,11 @@ class Volume(BaseAPI):
         super(Volume, self).__init__(*args, **kwargs)
 
     @classmethod
-    def get_object(cls, api_token, volume_id):
+    def get_object(cls, requester, volume_id):
         """
         Class method that will return an Volume object by ID.
         """
-        volume = cls(token=api_token, id=volume_id)
+        volume = cls(requester=requester, id=volume_id)
         volume.load()
         return volume
 
@@ -188,8 +188,7 @@ class Volume(BaseAPI):
         data = self.get_data("volumes/%s/snapshots/" % self.id)
         snapshots = list()
         for jsond in data[u'snapshots']:
-            snapshot = Snapshot(**jsond)
-            snapshot.token = self.tokens
+            snapshot = Snapshot(**jsond, requester=self._requester)
             snapshots.append(snapshot)
 
         return snapshots


### PR DESCRIPTION
Currently there is no way to consistently override request behavior, because API calls can be disjointed by invoking constructors.
Proposed solution is to chain all calls from the `Manager` class and propagate `Requester` responsible for performing actual api calls..